### PR TITLE
Upgrade SDG fork of module to v0.11.3 release

### DIFF
--- a/example-service/backend.tf
+++ b/example-service/backend.tf
@@ -2,17 +2,17 @@
 #
 # Copyright (c) 2021 Board of Trustees University of Illinois
 
-terraform {
-  backend "s3" {
-    region         = "us-east-2"
-    dynamodb_table = "terraform"
-    encrypt        = "true"
-
-    # must be unique to your AWS account; try replacing
-    # uiuc-tech-services-sandbox with the friendly name of your account
-    bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
-
-    # must be unique (within bucket) to this repository + environment
-    key = "FIXME/example-service/terraform.tfstate" #FIXME
-  }
-}
+#terraform {
+# backend "s3" {
+#   region         = "us-east-2"
+#   dynamodb_table = "terraform"
+#   encrypt        = "true"
+#
+#   # must be unique to your AWS account; try replacing
+#   # uiuc-tech-services-sandbox with the friendly name of your account
+#   bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
+#
+#   # must be unique (within bucket) to this repository + environment
+#   key = "FIXME/example-service/terraform.tfstate" #FIXME
+# }
+#}

--- a/global/backend.tf
+++ b/global/backend.tf
@@ -2,17 +2,17 @@
 #
 # Copyright (c) 2021 Board of Trustees University of Illinois
 
-terraform {
-  backend "s3" {
-    region         = "us-east-2"
-    dynamodb_table = "terraform"
-    encrypt        = "true"
-
-    # must be unique to your AWS account; try replacing
-    # uiuc-tech-services-sandbox with the friendly name of your account
-    bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
-
-    # must be unique (within bucket) to this repository + environment
-    key = "Shared Networking/global/terraform.tfstate"
-  }
-}
+#terraform {
+# backend "s3" {
+#   region         = "us-east-2"
+#   dynamodb_table = "terraform"
+#   encrypt        = "true"
+#
+#   # must be unique to your AWS account; try replacing
+#   # uiuc-tech-services-sandbox with the friendly name of your account
+#   bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
+#
+#   # must be unique (within bucket) to this repository + environment
+#   key = "Shared Networking/global/terraform.tfstate"
+# }
+#}

--- a/global/main.tf
+++ b/global/main.tf
@@ -98,7 +98,7 @@ resource "aws_ram_resource_share_accepter" "rs_accepter_us-east-2" {
 # Note: this solution is deprecated in favor of Transit Gateway.
 
 module "cgw_us-east-1" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/customer-gateways?ref=v0.11"
+  source = "../modules/customer-gateways"
 
   tags = var.tags
 
@@ -108,7 +108,7 @@ module "cgw_us-east-1" {
 }
 
 module "cgw_us-east-2" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/customer-gateways?ref=v0.11"
+  source = "../modules/customer-gateways"
 
   tags = var.tags
 

--- a/global/terraform.tfvars
+++ b/global/terraform.tfvars
@@ -3,7 +3,7 @@
 # Copyright (c) 2017 Board of Trustees University of Illinois
 
 # Your 12-digit AWS account number
-account_id = "999999999999" #FIXME
+#account_id = "999999999999" #FIXME
 
 # external RAM shares to accept from other accounts
 # (no longer needed for new shares within University of Illinois)
@@ -16,4 +16,3 @@ account_id = "999999999999" #FIXME
 #tags = {
 #  Contact = "example@illinois.edu"
 #}
-

--- a/modules/bootstrap/backend.tf
+++ b/modules/bootstrap/backend.tf
@@ -2,24 +2,22 @@
 #
 # Copyright (c) 2021 Board of Trustees University of Illinois
 
-/*
 # Initially the bootstrap environment's Terraform state is stored only as a
 # local file on your workstation, to avoid Catch-22.  AFTER the first
 # successful apply, you may optionally uncomment and edit this stanza to store
 # it remotely in the newly created bucket.
 
-terraform {
-  backend "s3" {
-    region         = "us-east-2"
-    dynamodb_table = "terraform"
-    encrypt        = "true"
-
-    # must be unique to your AWS account; try replacing
-    # uiuc-tech-services-sandbox with the friendly name of your account
-    bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
-
-    # must be unique (within bucket) to this repository + environment
-    key = "bootstrap/terraform.tfstate"
-  }
-}
-*/
+#terraform {
+# backend "s3" {
+#   region         = "us-east-2"
+#   dynamodb_table = "terraform"
+#   encrypt        = "true"
+#
+#   # must be unique to your AWS account; try replacing
+#   # uiuc-tech-services-sandbox with the friendly name of your account
+#   bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
+#
+#   # must be unique (within bucket) to this repository + environment
+#   key = "bootstrap/terraform.tfstate"
+# }
+#}

--- a/modules/campus-facing-subnet/module.tf
+++ b/modules/campus-facing-subnet/module.tf
@@ -131,7 +131,7 @@ output "cidr_block" {
 ## Resources
 
 module "subnet" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/subnet-common?ref=v0.11"
+  source = "../subnet-common"
 
   vpc_id                          = var.vpc_id
   name                            = var.name

--- a/modules/private-facing-subnet/module.tf
+++ b/modules/private-facing-subnet/module.tf
@@ -143,7 +143,7 @@ output "cidr_block" {
 ## Resources
 
 module "subnet" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/subnet-common?ref=v0.11"
+  source = "../subnet-common"
 
   vpc_id                          = var.vpc_id
   name                            = var.name

--- a/modules/public-facing-subnet/module.tf
+++ b/modules/public-facing-subnet/module.tf
@@ -124,7 +124,7 @@ output "cidr_block" {
 ## Resources
 
 module "subnet" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/subnet-common?ref=v0.11"
+  source = "../subnet-common"
 
   vpc_id                          = var.vpc_id
   name                            = var.name

--- a/modules/rdns-forwarder/module.tf
+++ b/modules/rdns-forwarder/module.tf
@@ -300,7 +300,7 @@ resource "aws_instance" "forwarder" {
     # Terraform when a new AMI is released.  Note that yum update will still
     # get the latest packages regardless of which AMI we start from; see
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#repository-config
-    ignore_changes = [ami]
+    ignore_changes = [ami, private_ip]
   }
 
   # However, do force replacement if instance_architecture changes.

--- a/vpc/backend.tf
+++ b/vpc/backend.tf
@@ -2,30 +2,30 @@
 #
 # Copyright (c) 2021 Board of Trustees University of Illinois
 
-terraform {
-  backend "s3" {
-    region         = "us-east-2"
-    dynamodb_table = "terraform"
-    encrypt        = "true"
-
-    # must be unique to your AWS account; try replacing
-    # uiuc-tech-services-sandbox with the friendly name of your account
-    bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
-
-    # must be unique (within bucket) to this repository + environment
-    key = "Shared Networking/vpc/terraform.tfstate"
-  }
-}
+#terraform {
+# backend "s3" {
+#   region         = "us-east-2"
+#   dynamodb_table = "terraform"
+#   encrypt        = "true"
+#
+#   # must be unique to your AWS account; try replacing
+#   # uiuc-tech-services-sandbox with the friendly name of your account
+#   bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
+#
+#   # must be unique (within bucket) to this repository + environment
+#   key = "Shared Networking/vpc/terraform.tfstate"
+# }
+#}
 
 ## Read remote state from global environment
 
-data "terraform_remote_state" "global" {
-  backend = "s3"
-
-  # must match ../global/backend.tf
-  config = {
-    region = "us-east-2"
-    bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
-    key    = "Shared Networking/global/terraform.tfstate"
-  }
-}
+#data "terraform_remote_state" "global" {
+# backend = "s3"
+#
+# # must match ../global/backend.tf
+# config = {
+#   region = "us-east-2"
+#   bucket = "terraform.uiuc-tech-services-sandbox.aws.illinois.edu" #FIXME
+#   key    = "Shared Networking/global/terraform.tfstate"
+# }
+#}

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -430,6 +430,7 @@ module "public-facing-subnet" {
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "public" }
 
   tags              = var.tags
+  tags_subnet       = { Tier = each.value.type, SubnetType = each.value.type }
   name              = "${var.vpc_short_name}-${each.key}"
   availability_zone = each.value.availability_zone
   cidr_block        = each.value.cidr_block
@@ -449,6 +450,7 @@ module "campus-facing-subnet" {
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "campus" }
 
   tags              = var.tags
+  tags_subnet       = { Tier = each.value.type, SubnetType = each.value.type }
   name              = "${var.vpc_short_name}-${each.key}"
   availability_zone = each.value.availability_zone
   cidr_block        = each.value.cidr_block
@@ -470,6 +472,7 @@ module "private-facing-subnet" {
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "private" }
 
   tags              = var.tags
+  tags_subnet       = { Tier = each.value.type, SubnetType = each.value.type }
   name              = "${var.vpc_short_name}-${each.key}"
   availability_zone = each.value.availability_zone
   cidr_block        = each.value.cidr_block

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -19,12 +19,9 @@ terraform {
       version = "~> 2.2"
     }
   }
-
-  # README: Must opt in to optional attributes experimental feature.
-  experiments = [module_variable_optional_attrs]
-
-  # see backend.tf for remote state configuration
 }
+
+# See backend.tf for remote state configuration.
 
 ## Inputs (specified in terraform.tfvars)
 
@@ -63,10 +60,10 @@ variable "assign_ipv6_address_on_creation" {
 variable "subnets_by_availability_zone_suffix" {
   description = "Maps availability zone suffix (e.g. 'a' for us-east-2a) to subnet key to subnet details"
   type = map(map(object({
-        type         = string
-        cidr_block   = string
-        tags_subnet  = optional(map(string))
-      })))
+    type        = string
+    cidr_block  = string
+    tags_subnet = optional(map(string))
+  })))
 }
 
 variable "use_transit_gateway" {
@@ -110,7 +107,7 @@ variable "pcx_ids" {
 
 variable "tags" {
   description = "Optional custom tags for all taggable resources"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -261,7 +261,7 @@ locals {
 # deploying NAT gateways).
 
 module "nat" {
-  source   = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/nat-gateway?ref=v0.11"
+  source   = "../modules/nat-gateway"
   for_each = { for az_suffix,subnet_key in var.nat_gateways : "${var.region}${az_suffix}" => {
     az_suffix  = az_suffix
     subnet_key = subnet_key
@@ -308,7 +308,7 @@ resource "aws_vpn_gateway_attachment" "vgw_attachment" {
 }
 
 module "vpn1" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/vpn-connection?ref=v0.11"
+  source = "../modules/vpn-connection"
   count  = var.use_dedicated_vpn ? 1 : 0
 
   tags                = var.tags
@@ -343,7 +343,7 @@ resource "null_resource" "vpn1" {
 }
 
 module "vpn2" {
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/vpn-connection?ref=v0.11"
+  source = "../modules/vpn-connection"
   count  = var.use_dedicated_vpn ? 1 : 0
 
   tags                = var.tags
@@ -426,7 +426,7 @@ locals {
 }
 
 module "public-facing-subnet" {
-  source   = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/public-facing-subnet?ref=v0.11"
+  source   = "../modules/public-facing-subnet"
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "public" }
 
   tags              = var.tags
@@ -445,7 +445,7 @@ module "public-facing-subnet" {
 }
 
 module "campus-facing-subnet" {
-  source   = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/campus-facing-subnet?ref=v0.11"
+  source   = "../modules/campus-facing-subnet"
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "campus" }
 
   tags              = var.tags
@@ -466,7 +466,7 @@ module "campus-facing-subnet" {
 }
 
 module "private-facing-subnet" {
-  source   = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/private-facing-subnet?ref=v0.11"
+  source   = "../modules/private-facing-subnet"
   for_each = { for k,v in local.subnet_details: k=>v if v.type == "private" }
 
   tags              = var.tags

--- a/vpc/rdns.tf
+++ b/vpc/rdns.tf
@@ -97,7 +97,7 @@ resource "aws_vpc_dhcp_options_association" "dhcp_assoc_option2" {
 
 module "rdns-a" {
   count  = (var.rdns_option == 3 || var.rdns_transition) ? 1 : 0
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/rdns-forwarder?ref=v0.11"
+  source = "../modules/rdns-forwarder"
 
   tags = merge(var.tags, {
     Name = "${var.vpc_short_name}-rdns-a"
@@ -138,7 +138,7 @@ resource "null_resource" "rdns-a" {
 
 module "rdns-b" {
   count  = (var.rdns_option == 3 || var.rdns_transition) ? 1 : 0
-  source = "git::https://github.com/techservicesillinois/aws-enterprise-vpc.git//modules/rdns-forwarder?ref=v0.11"
+  source = "../modules/rdns-forwarder"
 
   tags = merge(var.tags, {
     Name = "${var.vpc_short_name}-rdns-b"

--- a/vpc/terraform.tfvars
+++ b/vpc/terraform.tfvars
@@ -1,25 +1,25 @@
 #   # This file supplies values for the variables defined in *.tf
 #   #
 #   # Copyright (c) 2017 Board of Trustees University of Illinois
-#   
+#
 #   # Your 12-digit AWS account number
 #   account_id = "999999999999" #FIXME
-#   
+#
 #   # AWS region for this VPC, e.g. us-east-2
 #   region = "us-east-2"
-#   
+#
 #   # short name of this VPC, e.g. "foobar1" if the full name is "aws-foobar1-vpc"
 #   vpc_short_name = "foobar1" #FIXME
-#   
+#
 #   # entire IPv4 CIDR block allocated by Technology Services for this VPC
 #   vpc_cidr_block = "192.0.2.0/24" #FIXME
-#   
+#
 #   # Request an Amazon-provided IPv6 CIDR block (/56) for this VPC?
 #   assign_generated_ipv6_cidr_block = true
-#   
+#
 #   # Should new network interfaces on IPv6-enabled subnets automatically get IPv6 addresses?
 #   assign_ipv6_address_on_creation = false
-#   
+#
 #   # By default we will create four Subnets: one public-facing and one
 #   # campus-facing in each of two Availability Zones.
 #   #
@@ -77,34 +77,34 @@
 #       #}
 #     }
 #   }
-#   
+#
 #   # Should this VPC attach to (and create routes toward) a Transit Gateway?
 #   use_transit_gateway = true
-#   
+#
 #   # Specify one subnet per Availability Zone to be used for the Transit Gateway
 #   # attachment (may be public-, campus-, or private-facing)
 #   transit_gateway_attachment_subnets = {
 #     a = "public1-a-net"
 #     b = "public1-b-net"
 #   }
-#   
+#
 #   # If you need private-facing subnets with outbound Internet access, specify one
 #   # NAT gateway per availability zone (attached to a public-facing subnet).
 #   nat_gateways = {
 #     #a = "public1-a-net"
 #     #b = "public1-b-net"
 #   }
-#   
+#
 #   # Add VPC Peering Connection IDs here *after* the peering is created
 #   #pcx_ids = ["pcx-abcd1234"]
-#   
+#
 #   # See rdns.tf for explanation, and be sure to read and understand
 #   # [modules/rdns-forwarder/README.md] before deploying Option 3.
 #   #rdns_option = 1
-#   
+#
 #   # IPv4 addresses of Core Services Resolvers reachable from this VPC
 #   #core_services_resolvers = ["10.224.1.50", "10.224.1.100"]
-#   
+#
 #   # Interface VPC Endpoints for AWS services, not created by default since each
 #   # interface incurs cost and consumes an IP address.  Specify the ones you need.
 #   # The literal substring `{{REGION}}` will be replaced by var.region
@@ -120,16 +120,16 @@
 #     #"com.amazonaws.{{REGION}}.sns",
 #     #"com.amazonaws.{{REGION}}.ssm",
 #   ]
-#   
+#
 #   # Specify one subnet per Availability Zone to be used for Interface VPC
 #   # Endpoints (may be public-, campus-, or private-facing)
 #   interface_vpc_endpoint_subnets = {
 #     a = "public1-a-net"
 #     b = "public1-b-net"
 #   }
-#   
+#
 #   # Optional custom tags for all taggable resources
 #   #tags = {
 #   #  Contact = "example@illinois.edu"
 #   #}
-#   
+#

--- a/vpc/terraform.tfvars
+++ b/vpc/terraform.tfvars
@@ -1,135 +1,135 @@
-# This file supplies values for the variables defined in *.tf
-#
-# Copyright (c) 2017 Board of Trustees University of Illinois
-
-# Your 12-digit AWS account number
-account_id = "999999999999" #FIXME
-
-# AWS region for this VPC, e.g. us-east-2
-region = "us-east-2"
-
-# short name of this VPC, e.g. "foobar1" if the full name is "aws-foobar1-vpc"
-vpc_short_name = "foobar1" #FIXME
-
-# entire IPv4 CIDR block allocated by Technology Services for this VPC
-vpc_cidr_block = "192.0.2.0/24" #FIXME
-
-# Request an Amazon-provided IPv6 CIDR block (/56) for this VPC?
-assign_generated_ipv6_cidr_block = true
-
-# Should new network interfaces on IPv6-enabled subnets automatically get IPv6 addresses?
-assign_ipv6_address_on_creation = false
-
-# By default we will create four Subnets: one public-facing and one
-# campus-facing in each of two Availability Zones.
-#
-# Each subnet's cidr_block must be a subset of the overall vpc_cidr_block.
-#
-# Hint: use e.g. `ipcalc 192.0.2.0/24 26 --nobinary` to display all possible
-# /26 subnets within your vpc_cidr_block, and
-# `ipcalc 192.0.2.0/24 27 --nobinary` to display all possible /27 subnets.
-# (http://jodies.de/ipcalc-archive/ipcalc-0.41/ipcalc)
-#
-# You are free to choose a combination of differently sized subnets, so long as
-# the actual addresses don't overlap (i.e. the Broadcast address at the end of
-# your first subnet must be smaller than the base Network address at the
-# beginning of your second one, and so on).
-#
-# IPv6 subnet CIDRs are always /64, and will be calculated from the VPC's IPv6
-# CIDR block once it is known.
-#
-# Note that you can't resize or renumber existing Subnets in AWS once you
-# create them.  You _can_ delete and re-create them with Terraform, but they
-# will need to be emptied of service-oriented resources first.
-subnets_by_availability_zone_suffix = {
-  a = {
-    public1-a-net = {
-      type       = "public"
-      cidr_block = "192.0.2.0/27" #FIXME
-      ipv6_index = 1 # xx01::/64
-    }
-    campus1-a-net = {
-      type       = "campus"
-      cidr_block = "192.0.2.32/27" #FIXME
-      # ipv6 not supported
-    }
-    #private1-a-net = {
-    #  type       = "private"
-    #  cidr_block = "192.0.2.64/27" #FIXME
-    #  ipv6_index = 3 # xx03::/64
-    #}
-  }
-  b = {
-    public1-b-net = {
-      type       = "public"
-      cidr_block = "192.0.2.128/27" #FIXME
-      ipv6_index = 4 # xx04::/64
-    }
-    campus1-b-net = {
-      type       = "campus"
-      cidr_block = "192.0.2.160/27" #FIXME
-      # ipv6 not supported
-    }
-    #private1-b-net = {
-    #  type       = "private"
-    #  cidr_block = "192.0.2.192/27" #FIXME
-    #  ipv6_index = 6 # xx06::/64
-    #}
-  }
-}
-
-# Should this VPC attach to (and create routes toward) a Transit Gateway?
-use_transit_gateway = true
-
-# Specify one subnet per Availability Zone to be used for the Transit Gateway
-# attachment (may be public-, campus-, or private-facing)
-transit_gateway_attachment_subnets = {
-  a = "public1-a-net"
-  b = "public1-b-net"
-}
-
-# If you need private-facing subnets with outbound Internet access, specify one
-# NAT gateway per availability zone (attached to a public-facing subnet).
-nat_gateways = {
-  #a = "public1-a-net"
-  #b = "public1-b-net"
-}
-
-# Add VPC Peering Connection IDs here *after* the peering is created
-#pcx_ids = ["pcx-abcd1234"]
-
-# See rdns.tf for explanation, and be sure to read and understand
-# [modules/rdns-forwarder/README.md] before deploying Option 3.
-#rdns_option = 1
-
-# IPv4 addresses of Core Services Resolvers reachable from this VPC
-#core_services_resolvers = ["10.224.1.50", "10.224.1.100"]
-
-# Interface VPC Endpoints for AWS services, not created by default since each
-# interface incurs cost and consumes an IP address.  Specify the ones you need.
-# The literal substring `{{REGION}}` will be replaced by var.region
-#
-# Hint: use `aws ec2 describe-vpc-endpoint-services` to find more service names
-interface_vpc_endpoint_service_names = [
-  #"com.amazonaws.{{REGION}}.ec2",
-  #"com.amazonaws.{{REGION}}.ec2messages",
-  #"com.amazonaws.{{REGION}}.elasticloadbalancing",
-  #"com.amazonaws.{{REGION}}.kinesis-streams",
-  #"com.amazonaws.{{REGION}}.kms",
-  #"com.amazonaws.{{REGION}}.servicecatalog",
-  #"com.amazonaws.{{REGION}}.sns",
-  #"com.amazonaws.{{REGION}}.ssm",
-]
-
-# Specify one subnet per Availability Zone to be used for Interface VPC
-# Endpoints (may be public-, campus-, or private-facing)
-interface_vpc_endpoint_subnets = {
-  a = "public1-a-net"
-  b = "public1-b-net"
-}
-
-# Optional custom tags for all taggable resources
-#tags = {
-#  Contact = "example@illinois.edu"
-#}
-
+#   # This file supplies values for the variables defined in *.tf
+#   #
+#   # Copyright (c) 2017 Board of Trustees University of Illinois
+#   
+#   # Your 12-digit AWS account number
+#   account_id = "999999999999" #FIXME
+#   
+#   # AWS region for this VPC, e.g. us-east-2
+#   region = "us-east-2"
+#   
+#   # short name of this VPC, e.g. "foobar1" if the full name is "aws-foobar1-vpc"
+#   vpc_short_name = "foobar1" #FIXME
+#   
+#   # entire IPv4 CIDR block allocated by Technology Services for this VPC
+#   vpc_cidr_block = "192.0.2.0/24" #FIXME
+#   
+#   # Request an Amazon-provided IPv6 CIDR block (/56) for this VPC?
+#   assign_generated_ipv6_cidr_block = true
+#   
+#   # Should new network interfaces on IPv6-enabled subnets automatically get IPv6 addresses?
+#   assign_ipv6_address_on_creation = false
+#   
+#   # By default we will create four Subnets: one public-facing and one
+#   # campus-facing in each of two Availability Zones.
+#   #
+#   # Each subnet's cidr_block must be a subset of the overall vpc_cidr_block.
+#   #
+#   # Hint: use e.g. `ipcalc 192.0.2.0/24 26 --nobinary` to display all possible
+#   # /26 subnets within your vpc_cidr_block, and
+#   # `ipcalc 192.0.2.0/24 27 --nobinary` to display all possible /27 subnets.
+#   # (http://jodies.de/ipcalc-archive/ipcalc-0.41/ipcalc)
+#   #
+#   # You are free to choose a combination of differently sized subnets, so long as
+#   # the actual addresses don't overlap (i.e. the Broadcast address at the end of
+#   # your first subnet must be smaller than the base Network address at the
+#   # beginning of your second one, and so on).
+#   #
+#   # IPv6 subnet CIDRs are always /64, and will be calculated from the VPC's IPv6
+#   # CIDR block once it is known.
+#   #
+#   # Note that you can't resize or renumber existing Subnets in AWS once you
+#   # create them.  You _can_ delete and re-create them with Terraform, but they
+#   # will need to be emptied of service-oriented resources first.
+#   subnets_by_availability_zone_suffix = {
+#     a = {
+#       public1-a-net = {
+#         type       = "public"
+#         cidr_block = "192.0.2.0/27" #FIXME
+#         ipv6_index = 1 # xx01::/64
+#       }
+#       campus1-a-net = {
+#         type       = "campus"
+#         cidr_block = "192.0.2.32/27" #FIXME
+#         # ipv6 not supported
+#       }
+#       #private1-a-net = {
+#       #  type       = "private"
+#       #  cidr_block = "192.0.2.64/27" #FIXME
+#       #  ipv6_index = 3 # xx03::/64
+#       #}
+#     }
+#     b = {
+#       public1-b-net = {
+#         type       = "public"
+#         cidr_block = "192.0.2.128/27" #FIXME
+#         ipv6_index = 4 # xx04::/64
+#       }
+#       campus1-b-net = {
+#         type       = "campus"
+#         cidr_block = "192.0.2.160/27" #FIXME
+#         # ipv6 not supported
+#       }
+#       #private1-b-net = {
+#       #  type       = "private"
+#       #  cidr_block = "192.0.2.192/27" #FIXME
+#       #  ipv6_index = 6 # xx06::/64
+#       #}
+#     }
+#   }
+#   
+#   # Should this VPC attach to (and create routes toward) a Transit Gateway?
+#   use_transit_gateway = true
+#   
+#   # Specify one subnet per Availability Zone to be used for the Transit Gateway
+#   # attachment (may be public-, campus-, or private-facing)
+#   transit_gateway_attachment_subnets = {
+#     a = "public1-a-net"
+#     b = "public1-b-net"
+#   }
+#   
+#   # If you need private-facing subnets with outbound Internet access, specify one
+#   # NAT gateway per availability zone (attached to a public-facing subnet).
+#   nat_gateways = {
+#     #a = "public1-a-net"
+#     #b = "public1-b-net"
+#   }
+#   
+#   # Add VPC Peering Connection IDs here *after* the peering is created
+#   #pcx_ids = ["pcx-abcd1234"]
+#   
+#   # See rdns.tf for explanation, and be sure to read and understand
+#   # [modules/rdns-forwarder/README.md] before deploying Option 3.
+#   #rdns_option = 1
+#   
+#   # IPv4 addresses of Core Services Resolvers reachable from this VPC
+#   #core_services_resolvers = ["10.224.1.50", "10.224.1.100"]
+#   
+#   # Interface VPC Endpoints for AWS services, not created by default since each
+#   # interface incurs cost and consumes an IP address.  Specify the ones you need.
+#   # The literal substring `{{REGION}}` will be replaced by var.region
+#   #
+#   # Hint: use `aws ec2 describe-vpc-endpoint-services` to find more service names
+#   interface_vpc_endpoint_service_names = [
+#     #"com.amazonaws.{{REGION}}.ec2",
+#     #"com.amazonaws.{{REGION}}.ec2messages",
+#     #"com.amazonaws.{{REGION}}.elasticloadbalancing",
+#     #"com.amazonaws.{{REGION}}.kinesis-streams",
+#     #"com.amazonaws.{{REGION}}.kms",
+#     #"com.amazonaws.{{REGION}}.servicecatalog",
+#     #"com.amazonaws.{{REGION}}.sns",
+#     #"com.amazonaws.{{REGION}}.ssm",
+#   ]
+#   
+#   # Specify one subnet per Availability Zone to be used for Interface VPC
+#   # Endpoints (may be public-, campus-, or private-facing)
+#   interface_vpc_endpoint_subnets = {
+#     a = "public1-a-net"
+#     b = "public1-b-net"
+#   }
+#   
+#   # Optional custom tags for all taggable resources
+#   #tags = {
+#   #  Contact = "example@illinois.edu"
+#   #}
+#   


### PR DESCRIPTION
This PR incorporates the latest version of the module by its maintainer into the SDG fork. It also includes a workaround for hardcoded IPs in the rdns forwarder code, now that we have switched from using rdns_option 1 to rdns-option 3.
